### PR TITLE
ffi-bundler-fix ver

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -153,7 +153,7 @@ GEM
       activemodel (= 5.0.7.2)
       activerecord (= 5.0.7.2)
       activesupport (= 5.0.7.2)
-      bundler (>= 1.3.0)
+      bundler
       railties (= 5.0.7.2)
       sprockets-rails (>= 2.0.0)
     rails-controller-testing (1.0.4)
@@ -175,7 +175,7 @@ GEM
     rake (12.3.2)
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
-      ffi (~> 1.0)
+      ffi (>= 0.5.0, < 2)
     regexp_parser (1.5.1)
     responders (2.4.1)
       actionpack (>= 4.2.0, < 6.0)


### PR DESCRIPTION
### WHY bandle install エラー

### WHAT bunderのver削除
ffiを1.11.10に変更